### PR TITLE
enh: Google Discover

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -112,6 +112,7 @@ const Seo = ({ title, desc, banner, pathname, article }) => {
       <html lang={data.site.siteMetadata.siteLanguage} />
       <meta name="description" content={seo.description} />
       <meta name="image" content={seo.image} />
+      <meta name="robots" content="max-image-preview:large" />
       <meta
         name="apple-mobile-web-app-title"
         content={data.site.siteMetadata.shortName}

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -2,11 +2,18 @@ import React from "react"
 import PropTypes from "prop-types"
 import { useStaticQuery, graphql } from "gatsby"
 
-const Seo = ({ title, desc, banner, pathname, article }) => {
+const Seo = ({
+  title,
+  desc,
+  banner,
+  pathname,
+  article,
+  datePublished,
+  dateModified,
+}) => {
   const data = useStaticQuery(graphql`
     query SeoQuery {
       site {
-        buildTime(formatString: "MMMM DD, YYYY")
         siteMetadata {
           defaultTitle: title
           titleAlt
@@ -80,8 +87,8 @@ const Seo = ({ title, desc, banner, pathname, article }) => {
           url: seo.image,
         },
         description: seo.description,
-        datePublished: data.site.buildTime,
-        dateModified: data.site.buildTime,
+        datePublished,
+        dateModified: dateModified || datePublished,
         author: {
           "@type": "Person",
           name: data.site.siteMetadata.author,
@@ -158,6 +165,8 @@ Seo.propTypes = {
   banner: PropTypes.string,
   pathname: PropTypes.string,
   article: PropTypes.bool,
+  datePublished: PropTypes.string,
+  dateModified: PropTypes.string,
 }
 
 Seo.defaultProps = {
@@ -166,4 +175,6 @@ Seo.defaultProps = {
   banner: null,
   pathname: null,
   article: false,
+  datePublished: null,
+  dateModified: null,
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,7 +28,6 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
         pathname={post.fields.slug}
         article={true}
         datePublished={post.frontmatter.date}
-        dateModified={post.frontmatter.lastModified}
       />
       <article style={{ backgroundColor: "white", padding: rhythm(1) }}>
         <h1 style={{ marginBottom: 0 }}>{post.frontmatter.title}</h1>
@@ -99,7 +98,6 @@ export const Head = ({ data }) => {
     pathname: post.fields.slug,
     article: true,
     datePublished: post.frontmatter.date,
-    dateModified: post.frontmatter.lastModified,
   })
 }
 
@@ -121,7 +119,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
-        lastModified(formatString: "MMMM DD, YYYY")
         description
         featuredImage
         tags

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -27,6 +27,8 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
         banner={post.frontmatter.featuredImage}
         pathname={post.fields.slug}
         article={true}
+        datePublished={post.frontmatter.date}
+        dateModified={post.frontmatter.lastModified}
       />
       <article style={{ backgroundColor: "white", padding: rhythm(1) }}>
         <h1 style={{ marginBottom: 0 }}>{post.frontmatter.title}</h1>
@@ -96,6 +98,8 @@ export const Head = ({ data }) => {
     banner: post.frontmatter.featuredImage,
     pathname: post.fields.slug,
     article: true,
+    datePublished: post.frontmatter.date,
+    dateModified: post.frontmatter.lastModified,
   })
 }
 
@@ -117,6 +121,7 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
+        lastModified(formatString: "MMMM DD, YYYY")
         description
         featuredImage
         tags


### PR DESCRIPTION
In `src/components/seo.jsx`, add a `<meta name="robots" content="max-image-preview:large" />` tag (or add the equivalent HTTP header in hosting config). Place it alongside the other meta tags returned by the `Seo` component so it applies to all pages.

Update `src/components/seo.jsx` to accept `datePublished` and `dateModified` props for `BlogPosting` JSON-LD instead of `site.buildTime`. In `src/templates/blog-post.js`, pass `post.frontmatter.date` (and optionally a new `frontmatter.lastModified` if you add it) into the `Seo` component. Ensure the JSON-LD uses those props when `article` is true.