### PR TITLE
fix(frontend): clear legacy Gatsby service worker cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ typings/
 # Build artifacts
 .cache/
 public/
+!astro/public/
+!astro/public/**
 
 # Astro files
 astro/.astro/

--- a/astro/package-lock.json
+++ b/astro/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
+        "@types/node": "^24.5.2",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -1715,6 +1716,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/unist": {
@@ -5861,6 +5872,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/astro/package.json
+++ b/astro/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@types/node": "^24.5.2",
     "typescript": "^5.9.3"
   }
 }

--- a/astro/public/sw.js
+++ b/astro/public/sw.js
@@ -1,0 +1,21 @@
+self.addEventListener("install", () => {
+  self.skipWaiting()
+})
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheKeys = await caches.keys()
+      await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)))
+
+      await self.registration.unregister()
+
+      const clients = await self.clients.matchAll({
+        includeUncontrolled: true,
+        type: "window",
+      })
+
+      await Promise.all(clients.map((client) => client.navigate(client.url)))
+    })(),
+  )
+})

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -82,6 +82,47 @@ const resolvedSocialImage = socialImage ?? getDefaultSocialImage()
     trackPageView()
   }
 
+  const unregisterLegacyServiceWorkers = async () => {
+    if (!("serviceWorker" in navigator) || !("caches" in window)) {
+      return
+    }
+
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.map(async (registration) => {
+          try {
+            await registration.update()
+          } catch {}
+        }),
+      )
+
+      await navigator.serviceWorker.register("/sw.js")
+
+      const cacheKeys = await caches.keys()
+      await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)))
+
+      await Promise.all(
+        registrations.map(async (registration) => {
+          try {
+            await registration.unregister()
+          } catch {}
+        }),
+      )
+    } catch {}
+  }
+
+  const handleControllerChange = () => {
+    if (sessionStorage.getItem("legacy-sw-cleanup-reloaded") === "1") {
+      return
+    }
+
+    sessionStorage.setItem("legacy-sw-cleanup-reloaded", "1")
+    window.location.reload()
+  }
+
   document.addEventListener("astro:page-load", setupAnalytics)
+  window.addEventListener("load", unregisterLegacyServiceWorkers)
+  navigator.serviceWorker?.addEventListener("controllerchange", handleControllerChange)
   setupAnalytics()
 </script>


### PR DESCRIPTION
astro/public/sw.js を追加して、旧 /sw.js 登録を上書きした後に caches を削除し、自分自身も unregister する自己破棄型 worker にしました。さらに astro/src/layouts/BaseLayout.astro で、Astro ページを受け取れたユーザーについては既存 service worker の update/unregister と cache 削除を積極的に走らせるようにしています。