### PR TITLE
fix(astro): restore GA pageview delivery and normalize footer cookie link weight

### DIFF
--- a/astro/src/lib/cookie-consent.ts
+++ b/astro/src/lib/cookie-consent.ts
@@ -71,8 +71,10 @@ export const initializeAnalytics = () => {
   window.gtag =
     window.gtag ||
     function gtag(...args: unknown[]) {
-      const command = Object.assign({ length: args.length }, args)
-      window.dataLayer?.push(command)
+      void args
+      // gtag.js expects the queued entry shape produced by the official snippet.
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer?.push(arguments)
     }
 
   if (!window.__gaInitialized) {

--- a/astro/src/lib/cookie-consent.ts
+++ b/astro/src/lib/cookie-consent.ts
@@ -71,7 +71,8 @@ export const initializeAnalytics = () => {
   window.gtag =
     window.gtag ||
     function gtag(...args: unknown[]) {
-      window.dataLayer?.push(args)
+      const command = Object.assign({ length: args.length }, args)
+      window.dataLayer?.push(command)
     }
 
   if (!window.__gaInitialized) {

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -544,7 +544,7 @@ img {
   border-radius: 0;
   background: transparent;
   color: var(--color-reef-surface);
-  font-weight: var(--weight-medium);
+  font-weight: inherit;
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 0.16em;


### PR DESCRIPTION
## Summary
- Fix Google Analytics event queuing so `page_view` requests are sent again from the Astro frontend
- Make the footer `Cookie Settings` control inherit the surrounding link weight instead of appearing bolder than adjacent links

## What changed
- Frontend
- Updated `astro/src/lib/cookie-consent.ts` to queue `gtag` calls using the official snippet shape expected by `gtag.js`, with a targeted ESLint suppression for `arguments`
- Updated `astro/src/styles/global.css` so `.footer-cookie-button` uses inherited font weight and matches neighboring footer links

## Testing
- Not run (not requested)

## Manual QA
- Confirm `g/collect` appears in the browser network panel after accepting cookies
- Confirm the footer `Cookie Settings` text matches the weight of `About`, `Topics`, `Privacy Policy`, and `RSS`
- Screenshot reference: footer navigation showing the cookie link with normal weight

## Risks or follow-ups
- The GA fix intentionally relies on `arguments` because `gtag.js` did not process the rest-parameter alternative correctly
- If lint rules are tightened further, keep the inline suppression or replace it only after verifying `g/collect` still fires