### PR TITLE
Add homepage language filtering and propagate post language metadata

### DIFF
--- a/astro/src/components/CookieConsentBanner.astro
+++ b/astro/src/components/CookieConsentBanner.astro
@@ -14,10 +14,8 @@ const privacyPolicyHref = "/privacy-policy/"
     <div class="cookie-banner__content">
       <h2>Analytics cookies are optional</h2>
       <p>
-        This site uses Google Analytics only if you allow it. We also use Amazon
-        affiliate links, and Amazon may apply its own tracking after you follow
-        those links. See the
-        <a href={privacyPolicyHref}>Privacy Policy</a> for details.
+        Allow anonymous analytics? Amazon may separately track affiliate-link
+        visits. <a href={privacyPolicyHref}>Privacy details</a>.
       </p>
     </div>
     <div class="cookie-banner__actions">

--- a/astro/src/layouts/PostLayout.astro
+++ b/astro/src/layouts/PostLayout.astro
@@ -1,10 +1,11 @@
 ---
 import BaseLayout from "./BaseLayout.astro"
 
-const { title, description, canonicalPath, canonicalUrl, socialImage } =
+const { title, description, lang, canonicalPath, canonicalUrl, socialImage } =
   Astro.props as {
     title?: string
     description?: string
+    lang?: string
     canonicalPath?: string
     canonicalUrl?: string
     socialImage?: string
@@ -14,6 +15,7 @@ const { title, description, canonicalPath, canonicalUrl, socialImage } =
 <BaseLayout
   title={title}
   description={description}
+  lang={lang}
   canonicalPath={canonicalPath}
   canonicalUrl={canonicalUrl}
   socialImage={socialImage}

--- a/astro/src/pages/[slug].astro
+++ b/astro/src/pages/[slug].astro
@@ -37,6 +37,7 @@ const localizedHeadings = isJapanese
 <PostLayout
   title={post.data.title}
   description={post.data.description}
+  lang={post.data.lang}
   canonicalPath={`/${getPostSlug(post)}/`}
   canonicalUrl={getPostCanonicalUrl(post)}
   socialImage={getPostSocialImage(post)}

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -25,12 +25,25 @@ const mostRead = await getMostReadPosts(5)
   <section class="section home-section">
     <div class="section-header">
       <h2 class="section-title">Recent posts</h2>
+      <div class="language-filter" aria-label="Filter posts by language">
+        <button type="button" class="language-filter__button" data-language-filter="all" aria-pressed="true">
+          All
+        </button>
+        <button type="button" class="language-filter__button" data-language-filter="en" aria-pressed="false">
+          English
+        </button>
+        <button type="button" class="language-filter__button" data-language-filter="ja" aria-pressed="false">
+          日本語
+        </button>
+      </div>
     </div>
     {
       posts.length > 0 ? (
         <div class="divider-list">
           {posts.map((post, index) => (
-            <PostCard post={post} priority={index === 0} />
+            <div data-post-language={post.data.lang ?? "en"}>
+              <PostCard post={post} priority={index === 0} />
+            </div>
           ))}
         </div>
       ) : (
@@ -39,6 +52,7 @@ const mostRead = await getMostReadPosts(5)
         </div>
       )
     }
+    <p class="sr-only" aria-live="polite" data-language-filter-status></p>
     <Pagination currentPage={1} totalPages={totalPages} />
   </section>
 
@@ -85,3 +99,49 @@ const mostRead = await getMostReadPosts(5)
     <AuthorSummary />
   </section>
 </HomeLayout>
+
+<script>
+  const setupLanguageFilter = () => {
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("[data-language-filter]")
+    )
+    const posts = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-post-language]")
+    )
+    const status = document.querySelector<HTMLElement>(
+      "[data-language-filter-status]"
+    )
+
+    if (buttons.length === 0 || posts.length === 0) return
+
+    const applyFilter = (language: string) => {
+      let visibleCount = 0
+      for (const post of posts) {
+        const visible =
+          language === "all" || post.dataset.postLanguage === language
+        post.hidden = !visible
+        if (visible) visibleCount += 1
+      }
+
+      for (const button of buttons) {
+        button.setAttribute(
+          "aria-pressed",
+          String(button.dataset.languageFilter === language)
+        )
+      }
+
+      if (status) {
+        status.textContent = `${visibleCount} posts shown on this page.`
+      }
+    }
+
+    for (const button of buttons) {
+      button.addEventListener("click", () => {
+        applyFilter(button.dataset.languageFilter ?? "all")
+      })
+    }
+  }
+
+  document.addEventListener("astro:page-load", setupLanguageFilter)
+  setupLanguageFilter()
+</script>

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -69,8 +69,8 @@ body::after {
 
 body::before {
   top: 4.5rem;
-  left: -8rem;
-  width: 24rem;
+  left: -18rem;
+  width: 22rem;
   height: 24rem;
   border-radius: 50%;
   background: radial-gradient(
@@ -83,8 +83,8 @@ body::before {
 
 body::after {
   top: 18rem;
-  right: -10rem;
-  width: 28rem;
+  right: -16rem;
+  width: 22rem;
   height: 28rem;
   border-radius: 50%;
   background: radial-gradient(
@@ -105,8 +105,8 @@ main::before {
   content: "";
   position: absolute;
   top: 8rem;
-  right: -6rem;
-  width: min(26rem, 40vw);
+  right: -14rem;
+  width: min(20rem, 28vw);
   height: 32rem;
   pointer-events: none;
   z-index: -1;
@@ -175,7 +175,7 @@ img {
 }
 
 .panel {
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.92);
   border: 1px solid rgba(197, 210, 215, 0.7);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-line);
@@ -183,6 +183,7 @@ img {
 
 .surface {
   position: relative;
+  isolation: isolate;
 }
 
 .surface::before {
@@ -190,10 +191,16 @@ img {
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 0;
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.34), transparent 46%),
     linear-gradient(180deg, rgba(30, 140, 138, 0.04), transparent 70%);
   border-radius: inherit;
+}
+
+.surface > * {
+  position: relative;
+  z-index: 1;
 }
 
 .eyebrow {

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -369,6 +369,14 @@ img {
   font-family: inherit;
 }
 
+.article-head .article-title {
+  margin: 0 0 var(--space-2);
+}
+
+.article-head .article-dek {
+  margin: 0 0 var(--space-1);
+}
+
 .divider-list {
   display: grid;
   gap: var(--space-4);
@@ -831,7 +839,7 @@ img {
 
 @media (max-width: 720px) {
   .article-page.section {
-    margin-block: 0 var(--space-12);
+    margin-block: var(--space-3) var(--space-12);
   }
 
   .article-page {
@@ -892,22 +900,22 @@ img {
 
   .site-title-link {
     gap: 0.6rem;
-    font-size: 1.02rem !important;
+    font-size: 1.38rem !important;
   }
 
   .site-emblem {
-    width: 1.4rem;
-    height: 1.4rem;
+    width: 1.7rem;
+    height: 1.7rem;
   }
 
   .site-tagline {
     margin-top: 0.08rem !important;
-    font-size: 0.7rem !important;
+    font-size: 0.82rem !important;
   }
 
   .site-nav {
     gap: 0.72rem;
-    font-size: 0.7rem;
+    font-size: 0.82rem;
   }
 
   .section {

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -469,10 +469,11 @@ img {
 }
 
 .cookie-banner__inner {
-  width: min(100%, 48rem);
-  display: grid;
-  gap: var(--space-5);
-  padding: var(--space-5);
+  width: min(100%, 52rem);
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
   border: var(--border-strong);
   border-radius: var(--radius-xl);
   background:
@@ -488,13 +489,14 @@ img {
 
 .cookie-banner__content {
   display: grid;
-  gap: var(--space-3);
+  flex: 1 1 auto;
+  gap: var(--space-1);
 }
 
 .cookie-banner__content h2 {
   margin: 0;
   font-family: var(--font-ui);
-  font-size: clamp(1.15rem, 1.05rem + 0.4vw, 1.4rem);
+  font-size: var(--text-md);
   line-height: var(--leading-snug);
   letter-spacing: -0.03em;
   color: var(--color-ink-strong);
@@ -503,13 +505,13 @@ img {
 .cookie-banner__content p {
   margin: 0;
   color: var(--color-ink-soft);
-  font-size: var(--text-sm);
-  line-height: 1.7;
+  font-size: var(--text-xs);
+  line-height: 1.45;
 }
 
 .cookie-banner__actions {
   display: flex;
-  flex-wrap: wrap;
+  flex: 0 0 auto;
   justify-content: flex-end;
   gap: var(--space-3);
 }
@@ -580,8 +582,9 @@ img {
   }
 
   .cookie-banner__inner {
-    gap: var(--space-4);
-    padding: var(--space-4);
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-3);
   }
 
   .cookie-banner__actions {
@@ -589,9 +592,46 @@ img {
   }
 
   .cookie-banner__button {
-    flex: 1 1 12rem;
+    flex: 1 1 0;
     justify-content: center;
   }
+}
+
+.language-filter {
+  display: inline-flex;
+  gap: 0.125rem;
+  padding: 0.125rem;
+  border: 1px solid rgba(197, 210, 215, 0.58);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.28);
+  font-family: var(--font-ui);
+}
+
+.language-filter__button {
+  min-height: 1.75rem;
+  padding: 0.2rem 0.55rem;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-ink-soft);
+  font: inherit;
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.language-filter__button:hover {
+  color: var(--color-ink-strong);
+}
+
+.language-filter__button[aria-pressed="true"] {
+  background: rgba(30, 140, 138, 0.12);
+  color: var(--color-reef-deep);
+  font-weight: var(--weight-semibold);
+}
+
+.language-filter__button:focus-visible {
+  outline: 2px solid var(--color-reef-coral);
+  outline-offset: 2px;
 }
 
 .home-shell,

--- a/astro/src/styles/tokens.css
+++ b/astro/src/styles/tokens.css
@@ -20,7 +20,8 @@
     Charter, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia,
     serif;
   --font-body-ja:
-    "Hiragino Mincho ProN", "Yu Mincho", "BIZ UDPMincho", "MS PMincho", serif;
+    -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI",
+    "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
   --font-body: var(--font-body-en);
   --font-ui:
     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",


### PR DESCRIPTION
## Summary
- **Frontend**: add an on-page language filter to the homepage recent-posts list with accessible pressed-state buttons and live status updates.
- **Frontend**: propagate each post's `lang` through `PostLayout` and the single-post page so localized documents can receive the correct HTML language context.
- **UI polish**: tighten the cookie consent banner copy and restyle the banner, surface panels, and mobile header sizing for a cleaner presentation.
- **Typography**: update the Japanese body font stack to a sans-serif system stack for better readability and consistency.

## What changed
- **Frontend**
  - Added `All` / `English` / `日本語` filters on the homepage.
  - Wrapped each post card with a `data-post-language` marker and toggled visibility client-side.
  - Added an aria-live status message so screen readers can announce the current count.
- **Layouts and pages**
  - Extended `PostLayout` to accept `lang` and pass it through to `BaseLayout`.
  - Forwarded `post.data.lang` from `[slug].astro`.
- **Styles**
  - Refined cookie banner spacing, hierarchy, and button layout.
  - Adjusted surface/panel styling and mobile header scale.
  - Added styles for the language filter control.
  - Switched the Japanese body font stack to a sans-serif fallback chain.

## Testing
- Not run (not requested)

## Manual QA
- Verify the homepage filter switches between all posts, English posts, and Japanese posts.
- Confirm the selected filter updates `aria-pressed` state and the live count text changes after each click.
- Check that Japanese posts still render with the expected page language metadata on their detail pages.
- Review the cookie banner and mobile header spacing at narrow viewport widths.

## Risks or follow-ups
- The homepage filter is client-side only, so hidden posts still exist in the DOM and can be discovered without JavaScript.
- The Japanese body font change may need a follow-up pass after visual review on macOS and iOS.