### PR TITLE
feat(frontend): add static language-filtered post pages

### DIFF
--- a/astro/src/components/LanguageFilter.astro
+++ b/astro/src/components/LanguageFilter.astro
@@ -1,0 +1,25 @@
+---
+const { currentLanguage = "all" } = Astro.props as {
+  currentLanguage?: "all" | "en" | "ja"
+}
+
+const options = [
+  { language: "all", label: "All", href: "/" },
+  { language: "en", label: "English", href: "/language/en/" },
+  { language: "ja", label: "日本語", href: "/language/ja/" },
+] as const
+---
+
+<nav class="language-filter" aria-label="Filter posts by language">
+  {
+    options.map(({ language, label, href }) => (
+      <a
+        href={href}
+        class="language-filter__button"
+        aria-current={language === currentLanguage ? "page" : undefined}
+      >
+        {label}
+      </a>
+    ))
+  }
+</nav>

--- a/astro/src/components/Pagination.astro
+++ b/astro/src/components/Pagination.astro
@@ -1,10 +1,19 @@
 ---
-const { currentPage, totalPages } = Astro.props as {
+const {
+  currentPage,
+  totalPages,
+  basePath = "",
+} = Astro.props as {
   currentPage: number
   totalPages: number
+  basePath?: string
 }
 
-const hrefForPage = (page: number) => (page === 1 ? "/" : `/page/${page}/`)
+const normalizedBasePath = basePath.replace(/^\/+|\/+$/g, "")
+const hrefForPage = (page: number) => {
+  const root = normalizedBasePath ? `/${normalizedBasePath}/` : "/"
+  return page === 1 ? root : `${root}page/${page}/`
+}
 ---
 
 {

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import AuthorSummary from "../components/AuthorSummary.astro"
+import LanguageFilter from "../components/LanguageFilter.astro"
 import Pagination from "../components/Pagination.astro"
 import PopularSection from "../components/PopularSection.astro"
 import PostCard from "../components/PostCard.astro"
@@ -25,25 +26,13 @@ const mostRead = await getMostReadPosts(5)
   <section class="section home-section">
     <div class="section-header">
       <h2 class="section-title">Recent posts</h2>
-      <div class="language-filter" aria-label="Filter posts by language">
-        <button type="button" class="language-filter__button" data-language-filter="all" aria-pressed="true">
-          All
-        </button>
-        <button type="button" class="language-filter__button" data-language-filter="en" aria-pressed="false">
-          English
-        </button>
-        <button type="button" class="language-filter__button" data-language-filter="ja" aria-pressed="false">
-          日本語
-        </button>
-      </div>
+      <LanguageFilter currentLanguage="all" />
     </div>
     {
       posts.length > 0 ? (
         <div class="divider-list">
           {posts.map((post, index) => (
-            <div data-post-language={post.data.lang ?? "en"}>
-              <PostCard post={post} priority={index === 0} />
-            </div>
+            <PostCard post={post} priority={index === 0} />
           ))}
         </div>
       ) : (
@@ -52,7 +41,6 @@ const mostRead = await getMostReadPosts(5)
         </div>
       )
     }
-    <p class="sr-only" aria-live="polite" data-language-filter-status></p>
     <Pagination currentPage={1} totalPages={totalPages} />
   </section>
 
@@ -99,49 +87,3 @@ const mostRead = await getMostReadPosts(5)
     <AuthorSummary />
   </section>
 </HomeLayout>
-
-<script>
-  const setupLanguageFilter = () => {
-    const buttons = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("[data-language-filter]")
-    )
-    const posts = Array.from(
-      document.querySelectorAll<HTMLElement>("[data-post-language]")
-    )
-    const status = document.querySelector<HTMLElement>(
-      "[data-language-filter-status]"
-    )
-
-    if (buttons.length === 0 || posts.length === 0) return
-
-    const applyFilter = (language: string) => {
-      let visibleCount = 0
-      for (const post of posts) {
-        const visible =
-          language === "all" || post.dataset.postLanguage === language
-        post.hidden = !visible
-        if (visible) visibleCount += 1
-      }
-
-      for (const button of buttons) {
-        button.setAttribute(
-          "aria-pressed",
-          String(button.dataset.languageFilter === language)
-        )
-      }
-
-      if (status) {
-        status.textContent = `${visibleCount} posts shown on this page.`
-      }
-    }
-
-    for (const button of buttons) {
-      button.addEventListener("click", () => {
-        applyFilter(button.dataset.languageFilter ?? "all")
-      })
-    }
-  }
-
-  document.addEventListener("astro:page-load", setupLanguageFilter)
-  setupLanguageFilter()
-</script>

--- a/astro/src/pages/language/[language]/index.astro
+++ b/astro/src/pages/language/[language]/index.astro
@@ -1,0 +1,50 @@
+---
+import LanguageFilter from "../../../components/LanguageFilter.astro"
+import Pagination from "../../../components/Pagination.astro"
+import PostCard from "../../../components/PostCard.astro"
+import { site } from "../../../data/site"
+import HomeLayout from "../../../layouts/HomeLayout.astro"
+import { getAllPosts, paginatePosts } from "../../../lib/posts"
+
+type Language = "en" | "ja"
+
+export async function getStaticPaths() {
+  return (["en", "ja"] as const).map((language) => ({
+    params: { language },
+    props: { language },
+  }))
+}
+
+const { language } = Astro.props as { language: Language }
+const allPosts = await getAllPosts()
+const languagePosts = allPosts.filter(
+  (post) => (post.data.lang ?? "en") === language
+)
+const { items, totalPages } = paginatePosts(languagePosts, 1, site.postsPerPage)
+const heading = language === "ja" ? "日本語の記事" : "English posts"
+---
+
+<HomeLayout
+  title={heading}
+  description={`${heading} from Hippocampus's Garden.`}
+  canonicalPath={`/language/${language}/`}
+>
+  <section class="section home-section">
+    <div class="section-header">
+      <h1 class="section-title">{heading}</h1>
+      <LanguageFilter currentLanguage={language} />
+    </div>
+    <div class="divider-list">
+      {
+        items.map((post, index) => (
+          <PostCard post={post} priority={index === 0} />
+        ))
+      }
+    </div>
+    <Pagination
+      currentPage={1}
+      totalPages={totalPages}
+      basePath={`/language/${language}`}
+    />
+  </section>
+</HomeLayout>

--- a/astro/src/pages/language/[language]/page/[page].astro
+++ b/astro/src/pages/language/[language]/page/[page].astro
@@ -1,0 +1,61 @@
+---
+import LanguageFilter from "../../../../components/LanguageFilter.astro"
+import Pagination from "../../../../components/Pagination.astro"
+import PostCard from "../../../../components/PostCard.astro"
+import { site } from "../../../../data/site"
+import HomeLayout from "../../../../layouts/HomeLayout.astro"
+import { getAllPosts, paginatePosts } from "../../../../lib/posts"
+
+type Language = "en" | "ja"
+
+export async function getStaticPaths() {
+  const allPosts = await getAllPosts()
+
+  return (["en", "ja"] as const).flatMap((language) => {
+    const posts = allPosts.filter(
+      (post) => (post.data.lang ?? "en") === language
+    )
+    const totalPages = Math.ceil(posts.length / site.postsPerPage)
+
+    return Array.from({ length: Math.max(0, totalPages - 1) }, (_, index) => ({
+      params: { language, page: String(index + 2) },
+      props: { language },
+    }))
+  })
+}
+
+const { language } = Astro.props as { language: Language }
+const page = Number(Astro.params.page ?? "2")
+const allPosts = await getAllPosts()
+const languagePosts = allPosts.filter(
+  (post) => (post.data.lang ?? "en") === language
+)
+const { items, totalPages, currentPage } = paginatePosts(
+  languagePosts,
+  page,
+  site.postsPerPage
+)
+const heading = language === "ja" ? "過去の日本語記事" : "Older English posts"
+---
+
+<HomeLayout
+  title={`${heading} — Page ${currentPage}`}
+  canonicalPath={`/language/${language}/page/${currentPage}/`}
+>
+  <section class="section home-section">
+    <div class="section-header">
+      <h1 class="section-title" style="font-size:var(--text-3xl);">
+        {heading}
+      </h1>
+      <LanguageFilter currentLanguage={language} />
+    </div>
+    <div class="divider-list">
+      {items.map((post) => <PostCard post={post} />)}
+    </div>
+    <Pagination
+      currentPage={currentPage}
+      totalPages={totalPages}
+      basePath={`/language/${language}`}
+    />
+  </section>
+</HomeLayout>

--- a/astro/src/pages/page/[page].astro
+++ b/astro/src/pages/page/[page].astro
@@ -1,5 +1,6 @@
 ---
 import HomeLayout from "../../layouts/HomeLayout.astro"
+import LanguageFilter from "../../components/LanguageFilter.astro"
 import Pagination from "../../components/Pagination.astro"
 import PostCard from "../../components/PostCard.astro"
 import { site } from "../../data/site"
@@ -31,7 +32,7 @@ const { items, totalPages, currentPage } = paginatePosts(
       <h1 class="section-title" style="font-size:var(--text-3xl);">
         Older posts
       </h1>
-      <a href="/">Back to latest</a>
+      <LanguageFilter currentLanguage="all" />
     </div>
     <div class="divider-list">
       {items.map((post) => <PostCard post={post} />)}

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -617,13 +617,15 @@ img {
   font: inherit;
   font-size: var(--text-xs);
   cursor: pointer;
+  text-decoration: none;
 }
 
 .language-filter__button:hover {
   color: var(--color-ink-strong);
 }
 
-.language-filter__button[aria-pressed="true"] {
+.language-filter__button[aria-pressed="true"],
+.language-filter__button[aria-current="page"] {
   background: rgba(30, 140, 138, 0.12);
   color: var(--color-reef-deep);
   font-weight: var(--weight-semibold);
@@ -749,6 +751,10 @@ img {
   font-weight: 700;
   letter-spacing: -0.04em;
   line-height: 1.18;
+}
+
+.post-row-copy.lang-ja p {
+  font-family: var(--font-body-ja);
 }
 
 .post-row-thumb {


### PR DESCRIPTION
## Summary
- Add static English and Japanese post listing pages with pagination
- Replace client-side language filtering with accessible links and active-page styling

## What changed
- Frontend: add language routes, language filter component, scoped pagination paths, and Japanese post typography
- Frontend: update latest and older post pages to use the shared language filter

## Testing
- Not run (not requested)

## Manual QA
- Not performed; no screenshot references available

## Risks or follow-ups
- Verify language routes, pagination links, active states, and Japanese typography in the browser