### PR TITLE
fix(frontend): align Japanese font styling

### DIFF
--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -28,6 +28,7 @@ html {
 }
 
 html:lang(ja) {
+  --font-ui: var(--font-body-ja);
   font-family: var(--font-body-ja);
 }
 

--- a/astro/src/styles/prose.css
+++ b/astro/src/styles/prose.css
@@ -7,7 +7,8 @@
   color: var(--color-ink);
 }
 
-.prose-ja {
+.prose-ja,
+.prose:lang(ja) {
   font-family: var(--font-body-ja);
 }
 

--- a/astro/src/styles/tokens.css
+++ b/astro/src/styles/tokens.css
@@ -20,8 +20,8 @@
     Charter, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia,
     serif;
   --font-body-ja:
-    -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI",
-    "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+    "Helvetica Neue", "Hiragino Sans", "Hiragino Kaku Gothic ProN", Arial,
+    "Noto Sans JP", Meiryo, sans-serif;
   --font-body: var(--font-body-en);
   --font-ui:
     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",


### PR DESCRIPTION
## Summary

- Improve Japanese font consistency across UI and prose content.

## What changed

- Frontend: apply the Japanese body font to UI text and `:lang(ja)` prose.
- Frontend: update the Japanese font fallback stack.

## Testing

- Not run (not requested)

## Manual QA

- Not run; no screenshots available.

## Risks or follow-ups

- Verify Japanese typography across supported browsers and operating systems.