### PR TITLE
fix(frontend): prevent mobile code text autosizing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,7 +29,8 @@ export default defineConfig({
         light: "github-light",
         dark: "github-dark",
       },
-      wrap: true,
+      // `white-space: pre` keeps mobile WebKit from text-autosizing code.
+      wrap: false,
     },
     remarkPlugins: [remarkCodeMeta, remarkMermaid, remarkGfm, remarkMath],
     rehypePlugins: [[rehypeKatex, { strict: "ignore" }], rehypeSlug],

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -70,15 +70,16 @@
   padding: var(--space-4);
   border-radius: var(--radius-lg);
   overflow-x: auto;
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
+  /* `!important` keeps the WebKit-prefixed fallback in minified CSS. */
+  -webkit-text-size-adjust: none !important;
+  text-size-adjust: none;
   border: 1px solid rgba(158, 223, 214, 0.14);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .prose pre code {
   display: block;
-  min-width: max-content;
+  min-width: 0;
   color: inherit;
 }
 


### PR DESCRIPTION
## Summary

Prevent mobile WebKit from enlarging code blocks and preserve horizontal scrolling for long lines.

## What changed

- Frontend: disable code wrapping in Shiki configuration.
- Frontend: disable text autosizing for prose code blocks and allow code content to fit its container.

## Testing

- Not run (not requested).

## Manual QA

- Not performed; no screenshots available.
- Recommended scenarios: inspect short and long code blocks on mobile WebKit and verify font sizing remains consistent while long lines scroll horizontally.

## Risks or follow-ups

- Very long code lines may require horizontal scrolling on narrow screens.